### PR TITLE
Ensure tests run offline with node

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ const result = await tool.process(data);
 Generate comprehensive test suites with AI assistance.
 
 ```javascript
-const { TestFramework } = require('@cognitive/test-framework');
+const { createAITestFramework } = require('@cognitive/test-framework');
 
-const tests = await testFramework.generateTests(requirement);
-const results = await testFramework.runTests();
+const framework = createAITestFramework();
+const results = await framework.process({ path: './my-app' });
+console.log(results);
 ```
 
 ## 🏗️ Architecture

--- a/packages/ai-core/test-generation/ai-test-framework.js
+++ b/packages/ai-core/test-generation/ai-test-framework.js
@@ -5,7 +5,7 @@
  */
 
 const { TestFrameworkProcessor } = require('./test-framework-processor');
-const { AIDualMode } = require('../../adapters/dual-mode');
+const { AIDualMode } = require('../adapters/dual-mode');
 
 /**
  * Factory function to create AI-enhanced test framework

--- a/packages/test-framework/README.md
+++ b/packages/test-framework/README.md
@@ -11,7 +11,7 @@ npm install @cognitive/test-framework
 ## Basic Usage
 
 ```javascript
-const { createAITestFramework } = require('@cognitive/ai-core');
+const { createAITestFramework } = require('@cognitive/test-framework');
 
 const framework = createAITestFramework();
 framework.process({ path: './my-app' });

--- a/packages/test-framework/__tests__/cli.test.js
+++ b/packages/test-framework/__tests__/cli.test.js
@@ -1,0 +1,10 @@
+const { runCLI } = require('..');
+const path = require('path');
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+test('CLI runner processes project path in IDE mode', async () => {
+  const cwd = path.join(__dirname, 'fixtures');
+  const result = await runCLI([cwd]);
+  assert.deepStrictEqual(result, { analyzed: cwd });
+});

--- a/packages/test-framework/__tests__/create-framework.test.js
+++ b/packages/test-framework/__tests__/create-framework.test.js
@@ -1,34 +1,31 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const assert = require('node:assert');
+const { test } = require('node:test');
 
-// Mock the incorrect relative import used inside createAITestFramework
-jest.mock('../../adapters/dual-mode', () => require('../../ai-core/adapters/dual-mode'));
-
-const { createAITestFramework } = require('../../ai-core/test-generation');
+const { createAITestFramework } = require('..');
 
 const testResults = require('./fixtures/test-results.json');
 
-describe('createAITestFramework integration', () => {
-  test('generates context files for a sample project', async () => {
-    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-test-'));
-    const framework = createAITestFramework({ mode: 'ide', outputDir });
+test('createAITestFramework generates context files for a sample project', async () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-test-'));
+  const framework = createAITestFramework({ mode: 'ide', outputDir });
 
-    const result = await framework.process(testResults);
+  const result = await framework.process(testResults);
 
-    expect(result.mode).toBe('ide');
-    expect(result.status).toBe('success');
+  assert.strictEqual(result.mode, 'ide');
+  assert.strictEqual(result.status, 'success');
 
-    const expected = [
-      'context.json',
-      'analysis.md',
-      'prompts.md',
-      'copilot-guide.md',
-      'cursor-hints.json'
-    ];
+  const expected = [
+    'context.json',
+    'analysis.md',
+    'prompts.md',
+    'copilot-guide.md',
+    'cursor-hints.json'
+  ];
 
-    for (const file of expected) {
-      expect(fs.existsSync(path.join(outputDir, file))).toBe(true);
-    }
-  });
+  for (const file of expected) {
+    assert.ok(fs.existsSync(path.join(outputDir, file)));
+  }
 });

--- a/packages/test-framework/__tests__/processor.test.js
+++ b/packages/test-framework/__tests__/processor.test.js
@@ -1,16 +1,16 @@
 const { TestProcessor } = require('../lib/processor');
+const assert = require('node:assert');
+const { test } = require('node:test');
 
-describe('TestProcessor', () => {
-  test('analyzeForIDE returns analyzed path', async () => {
-    const processor = new TestProcessor();
-    const result = await processor.analyzeForIDE('my-project');
-    expect(result).toEqual({ analyzed: 'my-project' });
-  });
+test('TestProcessor analyzeForIDE returns analyzed path', async () => {
+  const processor = new TestProcessor();
+  const result = await processor.analyzeForIDE('my-project');
+  assert.deepStrictEqual(result, { analyzed: 'my-project' });
+});
 
-  test('processAIResponse maps ai output', async () => {
-    const processor = new TestProcessor();
-    const response = { choices: [{ message: { content: 'test content' } }] };
-    const result = await processor.processAIResponse(response, 'path');
-    expect(result).toEqual({ projectPath: 'path', generated: 'test content' });
-  });
+test('TestProcessor processAIResponse maps ai output', async () => {
+  const processor = new TestProcessor();
+  const response = { choices: [{ message: { content: 'test content' } }] };
+  const result = await processor.processAIResponse(response, 'path');
+  assert.deepStrictEqual(result, { projectPath: 'path', generated: 'test content' });
 });

--- a/packages/test-framework/bin/cli.js
+++ b/packages/test-framework/bin/cli.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 
-const { DualMode } = require('@cognitive/dual-mode');
+let DualMode;
+try {
+  ({ DualMode } = require('@cognitive/dual-mode'));
+} catch {
+  ({ DualMode } = require('../../dual-mode'));
+}
 const { TestProcessor } = require('../lib/processor');
 
 /**

--- a/packages/test-framework/index.js
+++ b/packages/test-framework/index.js
@@ -2,8 +2,15 @@
 
 const { TestProcessor } = require('./lib/processor');
 const { runCLI } = require('./bin/cli');
+let createAITestFramework;
+try {
+  ({ createAITestFramework } = require('@cognitive/ai-core/test-generation'));
+} catch {
+  ({ createAITestFramework } = require('../ai-core/test-generation'));
+}
 
 module.exports = {
   TestProcessor,
-  runCLI
+  runCLI,
+  createAITestFramework
 };

--- a/packages/test-framework/package.json
+++ b/packages/test-framework/package.json
@@ -7,7 +7,7 @@
     "cogtest": "bin/cli.js"
   },
   "scripts": {
-    "test": "jest",
+    "test": "node --test",
     "build": "echo \"Building test-framework\""
   },
   "repository": {
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/JackHemmert3113/cognitive-framework/tree/main/packages/test-framework#readme",
   "dependencies": {
-    "@cognitive/dual-mode": "^0.1.0"
+    "@cognitive/dual-mode": "^0.1.0",
+    "@cognitive/ai-core": "^0.1.0"
   },
   "peerDependencies": {
     "@cognitive/requirements": "^0.1.0"
@@ -38,6 +39,5 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
-    "jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- switch the test framework workspace to use Node's built‑in test runner
- add fallbacks for local package paths so tests don't require installed deps
- fix broken path for `AIDualMode` in `ai-test-framework.js`

## Testing
- `npm test`
