### PR TITLE
Enhance provider setup with dependency checks

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,7 @@ This guide shows how to install the Cognitive Framework and run the examples.
 ## Requirements
 
 - Node.js 16 or later
+- Provider libraries for API mode (e.g. `npm install openai`)
 
 ## Installation
 

--- a/packages/ai-core/README.md
+++ b/packages/ai-core/README.md
@@ -8,6 +8,18 @@ Utility modules for interacting with AI providers.
 npm install @cognitive/ai-core
 ```
 
+### Provider Dependencies
+
+API mode requires installing the package for your chosen AI provider. For example, to
+use OpenAI run:
+
+```bash
+npm install openai
+```
+
+If the provider package is missing the framework will fall back to a mock provider
+that returns placeholder responses.
+
 ## Basic Usage
 
 ```javascript


### PR DESCRIPTION
## Summary
- add helper to check for provider packages
- fall back to a mock provider when required packages are missing
- document provider dependencies in ai-core README
- mention provider packages in Getting Started guide

## Testing
- `npm test`
