### PR TITLE
Improve test generation via parser and Jest integration

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,19 @@
+# Troubleshooting Guide
+
+Quick fixes for common issues when using the Cognitive Framework.
+
+## Failing Tests 🚧 (Added in v1.2)
+
+If tests keep failing even after regenerating them, the Node.js module cache may be stale.
+
+```bash
+# Clear cache before rerunning
+node -e "Object.keys(require.cache).forEach(k => delete require.cache[k])"
+```
+
+Clearing the cache or restarting Node ensures updated modules are loaded.
+
+## More Help
+
+See [ARCHITECTURE](ARCHITECTURE.md) for internals or open an issue if you're stuck.
+

--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -102,7 +102,7 @@ Works out-of-the-box with:
 When you process a requirement, the following files may appear in `.ai/`:
 - `analysis.md` — AI-friendly requirement analysis
 - `acceptance_criteria.md` — Clear list of requirements
-- `prompts.md` — Prompts for AI code generation
+- `PROMPTS.md` — Prompts for AI code generation
 
 ---
 

--- a/packages/test-framework/lib/processor.js
+++ b/packages/test-framework/lib/processor.js
@@ -12,14 +12,14 @@ const { spawn } = require('child_process');
 
 class TestProcessor {
   async analyzeForIDE(projectPath) {
-    const { dir, files } = await this.createTempTests();
-    const results = await this.runTests(dir);
+    const { dir, files } = await this.createTempTests(projectPath);
+    const results = await this.runTests(dir, projectPath);
     return { analyzed: projectPath, tempDir: dir, files, results };
   }
 
   async prepareForAPI(projectPath) {
-    const { dir, files } = await this.createTempTests();
-    const results = await this.runTests(dir);
+    const { dir, files } = await this.createTempTests(projectPath);
+    const results = await this.runTests(dir, projectPath);
     return { prompt: `Generate tests for ${projectPath}`, tempDir: dir, files, results };
   }
 
@@ -28,21 +28,132 @@ class TestProcessor {
     return { projectPath, generated: content };
   }
 
-  async createTempTests() {
+  async createTempTests(projectPath = process.cwd()) {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cogtest-'));
-    const testFile = path.join(dir, 'generated.test.js');
-    const content = `const assert = require('node:assert');\nconst { test } = require('node:test');\n\ntest('auto generated sample', () => {\n  assert.strictEqual(1 + 1, 2);\n});\n`;
-    await fs.writeFile(testFile, content);
-    return { dir, files: [testFile] };
+    const parser = this.loadParser();
+
+    const jsFiles = await this.collectJS(projectPath);
+    const tests = [];
+
+    if (parser && jsFiles.length > 0) {
+      for (const file of jsFiles) {
+        const code = await fs.readFile(file, 'utf8');
+        let ast;
+        try {
+          ast = parser.parse(code, { sourceType: 'unambiguous' });
+        } catch {
+          continue;
+        }
+        const exported = this.extractExportedFunctions(ast);
+        for (const fn of exported) {
+          const rel = './' + path.relative(dir, file).replace(/\\/g, '/');
+          const name = fn === 'default' ? 'mod' : `mod.${fn}`;
+          const testFile = path.join(dir, `${path.basename(file, '.js')}-${fn}.test.js`);
+          const content = [
+            "const assert = require('node:assert');",
+            "const { test } = require('node:test');",
+            `const mod = require('${rel}');`,
+            '',
+            `const target = ${name};`,
+            '',
+            `test('${fn} executes', () => {`,
+            '  assert.doesNotThrow(() => {',
+            '    target(...Array(target.length).fill(1));',
+            '  });',
+            '});',
+            ''
+          ].join('\n');
+          await fs.writeFile(testFile, content);
+          tests.push(testFile);
+        }
+      }
+    }
+
+    if (tests.length === 0) {
+      const testFile = path.join(dir, 'generated.test.js');
+      const content = `const assert = require('node:assert');\nconst { test } = require('node:test');\n\ntest('auto generated sample', () => {\n  assert.strictEqual(1 + 1, 2);\n});\n`;
+      await fs.writeFile(testFile, content);
+      tests.push(testFile);
+    }
+
+    return { dir, files: tests };
   }
 
-  async runTests(dir) {
+  loadParser() {
+    try {
+      return require('@babel/parser');
+    } catch {
+      return null;
+    }
+  }
+
+  async collectJS(dir) {
+    const files = [];
+    try {
+      const items = await fs.readdir(dir, { withFileTypes: true });
+      for (const item of items) {
+        const p = path.join(dir, item.name);
+        if (item.isDirectory() && item.name !== 'node_modules') {
+          files.push(...await this.collectJS(p));
+        } else if (item.isFile() && item.name.endsWith('.js')) {
+          files.push(p);
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return files;
+  }
+
+  extractExportedFunctions(ast) {
+    const exported = [];
+    const walk = node => {
+      if (!node || typeof node !== 'object') return;
+      if (node.type === 'AssignmentExpression' && node.left && node.left.type === 'MemberExpression') {
+        const left = node.left;
+        if (left.object.type === 'Identifier' && left.object.name === 'module' && left.property.type === 'Identifier' && left.property.name === 'exports') {
+          if (node.right.type === 'FunctionExpression' || node.right.type === 'ArrowFunctionExpression') {
+            exported.push(node.right.id ? node.right.id.name : 'default');
+          } else if (node.right.type === 'ObjectExpression') {
+            for (const prop of node.right.properties || []) {
+              if ((prop.value.type === 'FunctionExpression' || prop.value.type === 'ArrowFunctionExpression') && prop.key.type === 'Identifier') {
+                exported.push(prop.key.name);
+              }
+            }
+          }
+        } else if (left.object.type === 'Identifier' && left.object.name === 'exports' && left.property.type === 'Identifier') {
+          if (node.right.type === 'FunctionExpression' || node.right.type === 'ArrowFunctionExpression') {
+            exported.push(left.property.name);
+          }
+        }
+      } else if (node.type === 'ExportNamedDeclaration') {
+        if (node.declaration && node.declaration.type === 'FunctionDeclaration' && node.declaration.id) {
+          exported.push(node.declaration.id.name);
+        }
+      } else if (node.type === 'ExportDefaultDeclaration') {
+        exported.push('default');
+      }
+
+      for (const key in node) {
+        const child = node[key];
+        if (Array.isArray(child)) child.forEach(walk);
+        else if (child && typeof child.type === 'string') walk(child);
+      }
+    };
+    walk(ast);
+    return exported;
+  }
+
+  async runTests(dir, projectDir = dir) {
     try {
       const { runCLI } = require('jest');
-      const { results } = await runCLI(
-        { runInBand: true, silent: true, rootDir: dir, testMatch: ['**/*.test.js'] },
-        [dir]
-      );
+      const config = {
+        runInBand: true,
+        silent: true,
+        rootDir: projectDir,
+        testMatch: [path.join(dir, '**/*.test.js').replace(/\\/g, '/')]
+      };
+      const { results } = await runCLI(config, [projectDir]);
       return { code: results.success ? 0 : 1, results };
     } catch {
       return this.runNodeTests(dir);

--- a/requirements/PROMPTS.md
+++ b/requirements/PROMPTS.md
@@ -1,0 +1,9 @@
+# AI Prompt Library
+
+Example prompts for generating requirements and specs with various personas. Copy and adapt as needed.
+
+- **Developer:** "Generate unit tests for the functions in foo.js".
+- **QA:** "List edge cases missing from the current suite." 
+
+Use these snippets with the tools in this repo or your favorite AI assistant.
+

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -6,7 +6,7 @@ This folder contains the canonical requirements contract, a worked example, and 
 
 - **contract.md** — The requirements format contract (canonical source)
 - **example.md** — A full example showing how requirements should be written and cross-linked
-- **prompts.md** — AI-ready prompts for generating requirements and specs by persona
+- **PROMPTS.md** — AI-ready prompts for generating requirements and specs by persona
 - **template-product-owner.md** — Requirements template for Product Owners/Business Stakeholders
 - **template-developer.md** — Requirements template for Technical Leads/Developers
 - **template-qa.md** — Requirements template for QA/Reviewers
@@ -30,7 +30,7 @@ This folder contains the canonical requirements contract, a worked example, and 
    See a canonical example of how to document and link requirements at multiple levels.
 
 3. **Use the templates and prompts**  
-   - Find persona-specific templates (`template-*.md`) and AI prompts (`prompts.md`) in this folder.  
+   - Find persona-specific templates (`template-*.md`) and AI prompts (`PROMPTS.md`) in this folder.
    - Use these when drafting new requirements, specs, or test plans—either directly, or as prompts for AI tools.
 
 4. **Add new requirements**  
@@ -54,5 +54,5 @@ See the FAQ in `contract.md` or ask in the project chat.
 
 ---
 **New:**  
-- See [`prompts.md`](./prompts.md) for ready-to-use AI prompts by persona.  
+- See [`PROMPTS.md`](./PROMPTS.md) for ready-to-use AI prompts by persona.
 - See the persona-specific templates (`template-*.md`) for a quick start on requirements, specs, and reviews.


### PR DESCRIPTION
## Summary
- enhance `TestProcessor` to scan project files for exported functions
- auto-generate tests using simple AST analysis (via `@babel/parser` if available)
- run tests with Jest's `runCLI` when available while keeping Node fallback
- add troubleshooting doc and rename `PROMPTS.md`

## Testing
- `npm test`
