### PR TITLE
Add auto JSDoc documentation blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ MIT License
 # Changelog
 
 All notable changes to this project will be documented here.
+## [1.0.0] - Documentation retrofit
+- Added auto-generated JSDoc headers across JS/TS files
+- Linked docs from README
 
 ## [0.1.0] - Initial release
 - Dual Mode support

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for how modules interact and how prompts 
 
 ## Version
 
-0.1.0 – Custom prompts supported (Added in v0.1).
+1.0.0 – Custom prompts supported (Added in v0.1).
 
 ## Links
 
@@ -177,4 +177,5 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for how modules interact and how prompts 
 - [PROMPTS](PROMPTS.md)
 - [RECIPES](RECIPES.md)
 - [TROUBLESHOOTING](TROUBLESHOOTING.md)
+- [CONTRIBUTING](CONTRIBUTING.md)
 - [CHANGELOG](CHANGELOG.md)

--- a/agent-core/index.js
+++ b/agent-core/index.js
@@ -1,3 +1,18 @@
+/**
+ * index.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./index.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 class UniversalAgentCore {
   constructor() {
     this.agents = new Map();
@@ -10,4 +25,10 @@ class UniversalAgentCore {
   }
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = { agentCore: new UniversalAgentCore() };

--- a/ai-dual-mode/examples/documentation.js
+++ b/ai-dual-mode/examples/documentation.js
@@ -120,4 +120,10 @@ if (require.main === module) {
   runExample();
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = { docProcessor };

--- a/ai-dual-mode/examples/test-framework.js
+++ b/ai-dual-mode/examples/test-framework.js
@@ -107,4 +107,10 @@ if (require.main === module) {
   runExample();
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = { testProcessor };

--- a/ai-dual-mode/index.js
+++ b/ai-dual-mode/index.js
@@ -1,2 +1,23 @@
+/**
+ * index.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./index.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 // Re-export the shared dual-mode implementation from ai-core
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = require('../packages/ai-core/adapters/dual-mode');

--- a/ai-dual-mode/lib/ai-test-framework_lib_ai-integration.js
+++ b/ai-dual-mode/lib/ai-test-framework_lib_ai-integration.js
@@ -1,3 +1,18 @@
+/**
+ * ai-test-framework_lib_ai-integration.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./ai-test-framework_lib_ai-integration.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { adapters } = require('@cognitive/ai-core');
 const { AIDualMode } = adapters;
 const path = require('path');
@@ -272,6 +287,12 @@ function createAITestFramework(config = {}) {
   });
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   TestFrameworkProcessor,
   createAITestFramework

--- a/ai-dual-mode/lib/validation.js
+++ b/ai-dual-mode/lib/validation.js
@@ -40,6 +40,12 @@ function validateConfig(config, mode) {
   return errors;
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   validateProcessor,
   validateConfig

--- a/forge-agent/src/cli/commands/badge.ts
+++ b/forge-agent/src/cli/commands/badge.ts
@@ -1,7 +1,28 @@
+/**
+ * badge.ts - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./badge.ts');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadAgentRules } from '../../helpers/rules-loader';
 
+/**
+ * badgeCommand exported API
+ * @example
+ * badgeCommand();
+ */
+// Added in v1.0
 export const badgeCommand = new Command('badge')
   .description('Generate README badge for agent compatibility')
   .option('-s, --status <status>', 'Badge status (compatible|needsSetup|incompatible)', 'compatible')

--- a/forge-agent/src/cli/commands/rules.ts
+++ b/forge-agent/src/cli/commands/rules.ts
@@ -1,7 +1,28 @@
+/**
+ * rules.ts - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./rules.ts');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadAgentRules } from '../../helpers/rules-loader';
 
+/**
+ * rulesCommand exported API
+ * @example
+ * rulesCommand();
+ */
+// Added in v1.0
 export const rulesCommand = new Command('rules')
   .description('Display current agent compatibility rules')
   .option('--json', 'Output as JSON')

--- a/forge-agent/src/cli/commands/validate.ts
+++ b/forge-agent/src/cli/commands/validate.ts
@@ -1,3 +1,18 @@
+/**
+ * validate.ts - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./validate.ts');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 import { Command } from 'commander';
 import chalk from 'chalk';
 import path from 'path';
@@ -5,6 +20,12 @@ import { validateProjectSetup } from '../../helpers/project-validator';
 import { validateTsConfig } from '../../helpers/tsconfig-validator';
 import { generateFixScript } from '../../helpers/project-validator';
 
+/**
+ * validateCommand exported API
+ * @example
+ * validateCommand();
+ */
+// Added in v1.0
 export const validateCommand = new Command('validate')
   .description('Validate project setup for agent compatibility')
   .option('-p, --path <path>', 'Project path to validate', '.')

--- a/forge-agent/src/helpers/agent-instructions.ts
+++ b/forge-agent/src/helpers/agent-instructions.ts
@@ -2,6 +2,12 @@
  * Agent Instructions for Forge Framework Projects
  */
 
+/**
+ * AGENT_INSTRUCTIONS exported API
+ * @example
+ * AGENT_INSTRUCTIONS();
+ */
+// Added in v1.0
 export const AGENT_INSTRUCTIONS = {
   typescript: {
     title: "TypeScript Command Usage",
@@ -49,6 +55,12 @@ export const AGENT_INSTRUCTIONS = {
   }
 };
 
+/**
+ * getAgentInstructions exported API
+ * @example
+ * getAgentInstructions();
+ */
+// Added in v1.0
 export function getAgentInstructions(context: 'pr-validation' | 'type-checking' | 'all'): string {
   const sections: string[] = [];
 

--- a/forge-agent/src/helpers/project-validator.ts
+++ b/forge-agent/src/helpers/project-validator.ts
@@ -7,6 +7,12 @@ import path from 'path';
 import { ValidationResult, ValidationIssue, ScriptCheckResult } from '../types';
 import { TYPESCRIPT_COMMANDS } from './typescript-commands';
 
+/**
+ * validateProjectSetup exported API
+ * @example
+ * validateProjectSetup();
+ */
+// Added in v1.0
 export async function validateProjectSetup(projectPath: string): Promise<ValidationResult> {
   const issues: ValidationIssue[] = [];
   const fixes: string[] = [];
@@ -56,6 +62,12 @@ export async function validateProjectSetup(projectPath: string): Promise<Validat
   };
 }
 
+/**
+ * hasRecommendedScripts exported API
+ * @example
+ * hasRecommendedScripts();
+ */
+// Added in v1.0
 export function hasRecommendedScripts(packageJson: any): ScriptCheckResult {
   const scripts = packageJson.scripts || {};
   const missingScripts: string[] = [];
@@ -72,6 +84,12 @@ export function hasRecommendedScripts(packageJson: any): ScriptCheckResult {
   };
 }
 
+/**
+ * generateFixScript exported API
+ * @example
+ * generateFixScript();
+ */
+// Added in v1.0
 export function generateFixScript(issues: ValidationIssue[]): string {
   const fixes: string[] = [];
 

--- a/forge-agent/src/helpers/rules-loader.ts
+++ b/forge-agent/src/helpers/rules-loader.ts
@@ -13,6 +13,12 @@ import {
 
 let cachedRules: AgentRules | null = null;
 
+/**
+ * loadAgentRules exported API
+ * @example
+ * loadAgentRules();
+ */
+// Added in v1.0
 export async function loadAgentRules(): Promise<AgentRules> {
   if (cachedRules) {
     return cachedRules;
@@ -32,6 +38,12 @@ export async function loadAgentRules(): Promise<AgentRules> {
   }
 }
 
+/**
+ * getPreferredCommand exported API
+ * @example
+ * getPreferredCommand();
+ */
+// Added in v1.0
 export async function getPreferredCommand(action: string): Promise<string | null> {
   const rules = await loadAgentRules();
   const preferred = rules.rules.typescript.commands.preferred.find(
@@ -41,6 +53,12 @@ export async function getPreferredCommand(action: string): Promise<string | null
   return preferred ? preferred.commands[0] : null;
 }
 
+/**
+ * isForbiddenCommand exported API
+ * @example
+ * isForbiddenCommand();
+ */
+// Added in v1.0
 export async function isForbiddenCommand(command: string): Promise<ForbiddenCheckResult> {
   const rules = await loadAgentRules();
 
@@ -57,11 +75,23 @@ export async function isForbiddenCommand(command: string): Promise<ForbiddenChec
   return { forbidden: false };
 }
 
+/**
+ * getBadge exported API
+ * @example
+ * getBadge();
+ */
+// Added in v1.0
 export async function getBadge(status: 'compatible' | 'needsSetup' | 'incompatible'): Promise<Badge> {
   const rules = await loadAgentRules();
   return rules.badges[status];
 }
 
+/**
+ * getErrorFix exported API
+ * @example
+ * getErrorFix();
+ */
+// Added in v1.0
 export async function getErrorFix(errorMessage: string): Promise<{
   pattern: string;
   cause: string;

--- a/forge-agent/src/helpers/tsconfig-validator.ts
+++ b/forge-agent/src/helpers/tsconfig-validator.ts
@@ -6,6 +6,12 @@ import fs from 'fs';
 import path from 'path';
 import { ValidationIssue, TsConfigValidationResult } from '../types';
 
+/**
+ * validateTsConfig exported API
+ * @example
+ * validateTsConfig();
+ */
+// Added in v1.0
 export async function validateTsConfig(projectPath: string): Promise<TsConfigValidationResult> {
   const issues: ValidationIssue[] = [];
   const fixes: string[] = [];

--- a/forge-agent/src/helpers/typescript-commands.ts
+++ b/forge-agent/src/helpers/typescript-commands.ts
@@ -4,6 +4,12 @@
 
 import { CommandOptions } from '../types';
 
+/**
+ * TYPESCRIPT_COMMANDS exported API
+ * @example
+ * TYPESCRIPT_COMMANDS();
+ */
+// Added in v1.0
 export const TYPESCRIPT_COMMANDS = {
   // Type checking commands
   typeCheck: {
@@ -29,6 +35,12 @@ export const TYPESCRIPT_COMMANDS = {
   }
 } as const;
 
+/**
+ * getTypeScriptCommand exported API
+ * @example
+ * getTypeScriptCommand();
+ */
+// Added in v1.0
 export function getTypeScriptCommand(operation: 'typeCheck' | 'build', options?: CommandOptions): string {
   if (operation === 'typeCheck') {
     if (options?.file) {

--- a/forge-agent/src/templates/package-json-template.ts
+++ b/forge-agent/src/templates/package-json-template.ts
@@ -4,6 +4,12 @@
 
 import { PackageJsonTemplate } from '../types';
 
+/**
+ * FORGE_PACKAGE_SCRIPTS exported API
+ * @example
+ * FORGE_PACKAGE_SCRIPTS();
+ */
+// Added in v1.0
 export const FORGE_PACKAGE_SCRIPTS: PackageJsonTemplate = {
   scripts: {
     // Type checking - REQUIRED for agent compatibility
@@ -35,6 +41,12 @@ export const FORGE_PACKAGE_SCRIPTS: PackageJsonTemplate = {
   }
 };
 
+/**
+ * mergePackageScripts exported API
+ * @example
+ * mergePackageScripts();
+ */
+// Added in v1.0
 export function mergePackageScripts(
   existing: any,
   template: PackageJsonTemplate = FORGE_PACKAGE_SCRIPTS

--- a/packages/ai-core/adapters/dual-mode-core.js
+++ b/packages/ai-core/adapters/dual-mode-core.js
@@ -476,6 +476,12 @@ class CIMode {
 }
 
 // Export everything needed
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   AIDualMode,
   IDEMode,

--- a/packages/ai-core/adapters/dual-mode.js
+++ b/packages/ai-core/adapters/dual-mode.js
@@ -1,2 +1,23 @@
+/**
+ * dual-mode.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./dual-mode.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 // Re-export shared dual-mode implementation
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = require('./dual-mode-core');

--- a/packages/ai-core/adapters/index.js
+++ b/packages/ai-core/adapters/index.js
@@ -7,6 +7,12 @@
 const { AIDualMode, IDEMode, APIMode, CIMode } = require('./dual-mode');
 const { validateProcessor, validateConfig } = require('./validation');
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   AIDualMode,
   IDEMode,

--- a/packages/ai-core/adapters/validation.js
+++ b/packages/ai-core/adapters/validation.js
@@ -42,6 +42,12 @@ function validateConfig(config, mode) {
   return errors;
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   validateProcessor,
   validateConfig

--- a/packages/ai-core/analyzers/index.js
+++ b/packages/ai-core/analyzers/index.js
@@ -4,6 +4,12 @@
  * Tools for analyzing code, requirements, and other content using AI.
  */
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   // Analyzers will be added here when code is moved
 };

--- a/packages/ai-core/analyzers/multi-language-orchestrator.js
+++ b/packages/ai-core/analyzers/multi-language-orchestrator.js
@@ -240,6 +240,12 @@ class RustAnalyzer extends BaseAnalyzer {
   }
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   MultiLanguageOrchestrator,
   JavaScriptAnalyzer,

--- a/packages/ai-core/cost-modules/index.js
+++ b/packages/ai-core/cost-modules/index.js
@@ -4,6 +4,12 @@
  * Tools for tracking, managing, and optimizing AI usage costs.
  */
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   // Cost modules will be added here when code is moved
 };

--- a/packages/ai-core/model-selectors/index.js
+++ b/packages/ai-core/model-selectors/index.js
@@ -4,6 +4,12 @@
  * Logic for selecting appropriate AI models based on context and requirements.
  */
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   // Model selectors will be added here when code is moved
 };

--- a/packages/ai-core/test-generation/ai-test-framework.js
+++ b/packages/ai-core/test-generation/ai-test-framework.js
@@ -34,6 +34,12 @@ function createAITestFramework(config = {}) {
   });
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   createAITestFramework
 };

--- a/packages/ai-core/test-generation/index.js
+++ b/packages/ai-core/test-generation/index.js
@@ -7,6 +7,12 @@
 const { TestFrameworkProcessor } = require('./test-framework-processor');
 const { createAITestFramework } = require('./ai-test-framework');
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   TestFrameworkProcessor,
   createAITestFramework

--- a/packages/ai-core/test-generation/test-framework-processor.js
+++ b/packages/ai-core/test-generation/test-framework-processor.js
@@ -1,3 +1,18 @@
+/**
+ * test-framework-processor.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./test-framework-processor.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const path = require('path');
 
 /**
@@ -247,6 +262,12 @@ ${analysis.slowTests.slice(0, 3).map(t => `- ${t.name} (${t.duration}ms)`).join(
   }
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   TestFrameworkProcessor
 };

--- a/packages/ai-core/utilities/index.js
+++ b/packages/ai-core/utilities/index.js
@@ -4,6 +4,12 @@
  * Shared utility functions for AI-related operations.
  */
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   // Utilities will be added here when code is moved
 };

--- a/packages/dual-mode/examples/simple-usage.js
+++ b/packages/dual-mode/examples/simple-usage.js
@@ -1,3 +1,18 @@
+/**
+ * simple-usage.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./simple-usage.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { adapters } = require('@cognitive/ai-core');
 const { AIDualMode } = adapters;
 

--- a/packages/dual-mode/index.js
+++ b/packages/dual-mode/index.js
@@ -1,7 +1,28 @@
+/**
+ * index.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./index.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 'use strict';
 
 const { DualMode } = require('./lib/dual-mode');
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   DualMode
 };

--- a/packages/dual-mode/lib/dual-mode.js
+++ b/packages/dual-mode/lib/dual-mode.js
@@ -1,3 +1,18 @@
+/**
+ * dual-mode.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./dual-mode.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 'use strict';
 
 /**
@@ -159,4 +174,10 @@ class DualMode {
   }
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = { DualMode };

--- a/packages/requirements/index.js
+++ b/packages/requirements/index.js
@@ -1,3 +1,18 @@
+/**
+ * index.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./index.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 'use strict';
 
 /**
@@ -19,6 +34,12 @@ class RequirementsFramework {
   }
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   RequirementsFramework
 };

--- a/packages/test-framework/__tests__/advanced-modes.test.js
+++ b/packages/test-framework/__tests__/advanced-modes.test.js
@@ -1,3 +1,18 @@
+/**
+ * advanced-modes.test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./advanced-modes.test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { createAITestFramework } = require('..');
 const assert = require('node:assert');
 const { test } = require('node:test');

--- a/packages/test-framework/__tests__/api-mode.test.js
+++ b/packages/test-framework/__tests__/api-mode.test.js
@@ -1,3 +1,18 @@
+/**
+ * api-mode.test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./api-mode.test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { createAITestFramework } = require('..');
 const Module = require('module');
 const path = require('path');

--- a/packages/test-framework/__tests__/cli.test.js
+++ b/packages/test-framework/__tests__/cli.test.js
@@ -1,3 +1,18 @@
+/**
+ * cli.test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./cli.test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { runCLI } = require('..');
 const path = require('path');
 const assert = require('node:assert');

--- a/packages/test-framework/__tests__/create-framework.test.js
+++ b/packages/test-framework/__tests__/create-framework.test.js
@@ -1,3 +1,18 @@
+/**
+ * create-framework.test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./create-framework.test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const fs = require('fs');
 const os = require('os');
 const path = require('path');

--- a/packages/test-framework/__tests__/fixtures/test-project/index.js
+++ b/packages/test-framework/__tests__/fixtures/test-project/index.js
@@ -1,1 +1,22 @@
+/**
+ * index.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./index.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
+/**
+ * add exported API
+ * @example
+ * add();
+ */
+// Added in v1.0
 module.exports = function add(a, b) { return a + b; };

--- a/packages/test-framework/__tests__/mocks/openai.js
+++ b/packages/test-framework/__tests__/mocks/openai.js
@@ -1,3 +1,18 @@
+/**
+ * openai.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./openai.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 class OpenAI {
   constructor() {}
   chat = {
@@ -8,4 +23,10 @@ class OpenAI {
     }
   };
 }
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = OpenAI;

--- a/packages/test-framework/__tests__/processor.test.js
+++ b/packages/test-framework/__tests__/processor.test.js
@@ -1,3 +1,18 @@
+/**
+ * processor.test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./processor.test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { TestProcessor } = require('../lib/processor');
 const assert = require('node:assert');
 const { test } = require('node:test');

--- a/packages/test-framework/bin/cli.js
+++ b/packages/test-framework/bin/cli.js
@@ -1,3 +1,18 @@
+/**
+ * cli.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./cli.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 #!/usr/bin/env node
 'use strict';
 
@@ -29,4 +44,10 @@ if (require.main === module) {
   });
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = { runCLI };

--- a/packages/test-framework/index.js
+++ b/packages/test-framework/index.js
@@ -1,3 +1,18 @@
+/**
+ * index.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./index.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 'use strict';
 
 const { TestProcessor } = require('./lib/processor');
@@ -9,6 +24,12 @@ try {
   ({ createAITestFramework } = require('../ai-core/test-generation'));
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = {
   TestProcessor,
   runCLI,

--- a/packages/test-framework/lib/processor.js
+++ b/packages/test-framework/lib/processor.js
@@ -1,3 +1,18 @@
+/**
+ * processor.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./processor.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 'use strict';
 
 /**
@@ -171,4 +186,10 @@ class TestProcessor {
   }
 }
 
+/**
+ * exported exported API
+ * @example
+ * exported();
+ */
+// Added in v1.0
 module.exports = { TestProcessor };

--- a/test.js
+++ b/test.js
@@ -1,2 +1,17 @@
+/**
+ * test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 const { agentCore } = require("./agent-core");
 agentCore.query("Hello!").then(r => console.log("✅", r));

--- a/tools/pr-linter.js
+++ b/tools/pr-linter.js
@@ -1,3 +1,18 @@
+/**
+ * pr-linter.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./pr-linter.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
 #!/usr/bin/env node
 /**
  * PR Linter for Cognitive Framework


### PR DESCRIPTION
## Summary
- generate JSDoc headers across JS/TS files
- link CONTRIBUTING doc in README and bump version to 1.0.0
- document retrofit changes in CHANGELOG

## Testing
- `npm test` *(fails: SyntaxError in bin/cli.js)*