### PR TITLE
Fix PR linter header detection

### DIFF
--- a/tools/pr-linter.js
+++ b/tools/pr-linter.js
@@ -13,7 +13,6 @@
 // 🧪 Tests
 // ⚙️ Config
 // 💡 Helpers or utilities
-#!/usr/bin/env node
 /**
  * PR Linter for Cognitive Framework
  *


### PR DESCRIPTION
## Summary
- adjust `tools/pr-linter.js` so the file-level header is the first line
- verify the PR linter runs successfully

## Testing
- `node tools/pr-linter.js`
- `npm test` *(fails: testCodeFailure)*