### PR TITLE
Add MIT license headers to package JS files

### DIFF
--- a/packages/ai-core/adapters/dual-mode-core.js
+++ b/packages/ai-core/adapters/dual-mode-core.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * Shared dual-mode implementation used by ai-core and ai-dual-mode
  *
  * Reusable architecture for AI-enhanced developer tools

--- a/packages/ai-core/adapters/dual-mode.js
+++ b/packages/ai-core/adapters/dual-mode.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * dual-mode.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/ai-core/adapters/index.js
+++ b/packages/ai-core/adapters/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/adapters
  * 
  * Adapters for various AI models and services.

--- a/packages/ai-core/adapters/validation.js
+++ b/packages/ai-core/adapters/validation.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/adapters/validation
  * 
  * Validation utilities for AI Dual Mode

--- a/packages/ai-core/analyzers/index.js
+++ b/packages/ai-core/analyzers/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/analyzers
  * 
  * Tools for analyzing code, requirements, and other content using AI.

--- a/packages/ai-core/analyzers/multi-language-orchestrator.js
+++ b/packages/ai-core/analyzers/multi-language-orchestrator.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/analyzers/multi-language-orchestrator
  * 
  * Orchestrates test analysis across multiple programming languages.

--- a/packages/ai-core/cost-modules/index.js
+++ b/packages/ai-core/cost-modules/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/cost-modules
  * 
  * Tools for tracking, managing, and optimizing AI usage costs.

--- a/packages/ai-core/index.js
+++ b/packages/ai-core/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core
  * 
  * Core AI functionality for the Cognitive Framework, including adapters, 

--- a/packages/ai-core/model-selectors/index.js
+++ b/packages/ai-core/model-selectors/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/model-selectors
  * 
  * Logic for selecting appropriate AI models based on context and requirements.

--- a/packages/ai-core/test-generation/ai-test-framework.js
+++ b/packages/ai-core/test-generation/ai-test-framework.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/test-generation/ai-test-framework
  * 
  * Factory function to create AI-enhanced test framework

--- a/packages/ai-core/test-generation/index.js
+++ b/packages/ai-core/test-generation/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/test-generation
  * 
  * AI-powered tools for generating and managing tests.

--- a/packages/ai-core/test-generation/test-framework-processor.js
+++ b/packages/ai-core/test-generation/test-framework-processor.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * test-framework-processor.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/ai-core/utilities/index.js
+++ b/packages/ai-core/utilities/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * @cognitive/ai-core/utilities
  * 
  * Shared utility functions for AI-related operations.

--- a/packages/dual-mode/examples/simple-usage.js
+++ b/packages/dual-mode/examples/simple-usage.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * simple-usage.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/dual-mode/index.js
+++ b/packages/dual-mode/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * index.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/dual-mode/lib/dual-mode.js
+++ b/packages/dual-mode/lib/dual-mode.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * dual-mode.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/requirements/index.js
+++ b/packages/requirements/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * index.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/advanced-modes.test.js
+++ b/packages/test-framework/__tests__/advanced-modes.test.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * advanced-modes.test.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/api-mode.test.js
+++ b/packages/test-framework/__tests__/api-mode.test.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * api-mode.test.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/cli.test.js
+++ b/packages/test-framework/__tests__/cli.test.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * cli.test.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/create-framework.test.js
+++ b/packages/test-framework/__tests__/create-framework.test.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * create-framework.test.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/fixtures/test-project/index.js
+++ b/packages/test-framework/__tests__/fixtures/test-project/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * index.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/mocks/openai.js
+++ b/packages/test-framework/__tests__/mocks/openai.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * openai.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/__tests__/processor.test.js
+++ b/packages/test-framework/__tests__/processor.test.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * processor.test.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/bin/cli.js
+++ b/packages/test-framework/bin/cli.js
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * cli.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/index.js
+++ b/packages/test-framework/index.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * index.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/packages/test-framework/lib/processor.js
+++ b/packages/test-framework/lib/processor.js
@@ -1,4 +1,9 @@
 /**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
  * processor.js - Cognitive Framework module
  * Auto generated documentation block.
  *

--- a/tools/add-license-headers.sh
+++ b/tools/add-license-headers.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Adds MIT license headers to JavaScript files under packages/ if missing.
+
+header="/**\n * Cognitive Framework\n *\n * MIT License\n */\n"
+
+find packages -name "*.js" | while read -r file; do
+  if ! grep -m1 -q "MIT License" "$file"; then
+    if head -n 1 "$file" | grep -q "^#!/"; then
+      # Keep shebang on first line
+      tail_content=$(tail -n +2 "$file")
+      {
+        echo "$(head -n 1 "$file")"
+        printf '%b' "$header"
+        echo "$tail_content"
+      } > "$file.tmp" && mv "$file.tmp" "$file"
+    else
+      {
+        printf '%b' "$header"
+        cat "$file"
+      } > "$file.tmp" && mv "$file.tmp" "$file"
+    fi
+  fi
+done


### PR DESCRIPTION
## Summary
- add MIT license header to all JavaScript files under `packages/`
- include helper script to automate license header injection

## Testing
- `npm test`