### PR TITLE
Add analyze script for AI test framework

### DIFF
--- a/packages/ai-test-framework/analyze.js
+++ b/packages/ai-test-framework/analyze.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+"use strict";
+
+const path = require("path");
+const { createAITestFramework } = require("./index");
+
+async function main() {
+  const file = process.argv[2];
+  if (!file) {
+    console.error("Usage: npm run analyze <file>");
+    process.exit(1);
+  }
+
+  let testResults;
+  try {
+    testResults = require(path.resolve(file));
+  } catch (err) {
+    console.error(`Failed to load ${file}:`, err.message);
+    process.exit(1);
+  }
+
+  const framework = createAITestFramework({ mode: "ide" });
+  const result = await framework.process(testResults);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/ai-test-framework/package.json
+++ b/packages/ai-test-framework/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "NODE_V8_COVERAGE=coverage node --test",
     "test:coverage": "NODE_V8_COVERAGE=coverage node --test",
-    "build": "echo \"Building test-framework\""
+    "build": "echo \"Building test-framework\"",
+    "analyze": "node analyze.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- implement `analyze.js` helper using the framework in IDE mode
- expose new `analyze` npm script in `@cognitive/ai-test-framework`

## Testing
- `npm test`