### PR TITLE
Add requirements workflow CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ const requirement = await framework.process(
 );
 ```
 
+To directly run tests using your requirement, use the integrated helper:
+
+```javascript
+const { processAndTest } = require('@cognitive/requirements');
+await processAndTest('./requirement.md', './my-app');
+```
+
 ### Dual Mode
 Build tools that work both as IDE assistants and standalone automation.
 

--- a/packages/ai-test-framework/__tests__/requirements-integration.test.js
+++ b/packages/ai-test-framework/__tests__/requirements-integration.test.js
@@ -1,0 +1,50 @@
+/**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
+ * requirements-integration.test.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./requirements-integration.test.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
+const { processAndTest } = require('../../requirements');
+const path = require('path');
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const requirement = {
+  id: 'TASK-1',
+  type: 'task',
+  title: 'demo',
+  metadata: {
+    owner: 'tester',
+    status: 'open',
+    priority: 'low',
+    estimate: '1h',
+    tags: 'demo',
+    created: '2024-01-01',
+    lastUpdated: '2024-01-01',
+    team: 'dev'
+  },
+  acceptanceCriteria: ['works']
+};
+
+test('processAndTest returns requirement and test result', async () => {
+  const project = path.join(__dirname, 'fixtures');
+  const result = await processAndTest(requirement, project);
+  assert.strictEqual(result.requirement.id, 'TASK-1');
+  assert.strictEqual(result.testResult.analyzed, project);
+  assert.strictEqual(result.testResult.results.code, 0);
+});
+

--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -87,6 +87,11 @@ framework.process(rawText)
 - **requirement:** Structured requirement object or plain text
 - **Returns:** Promise resolving to processed requirement data
 
+### `.processAndTest(requirement | text, projectPath, options?)`
+
+- **projectPath:** Directory for the AI Test Framework (default: current working directory)
+- **Returns:** Promise resolving to `{ requirement, testResult }`
+
 ---
 
 ## 🛠️ Integration
@@ -94,6 +99,14 @@ framework.process(rawText)
 Works out-of-the-box with:
 - [`@cognitive/dual-mode`](../dual-mode) — Dual-mode context file/API integration
 - [`@cognitive/ai-test-framework`](../ai-test-framework) — Automatic test generation
+
+### Command Line
+
+Use the `cogreq` command to process a requirement file and immediately run the AI Test Framework:
+
+```bash
+cogreq requirement.md ./my-project
+```
 
 ---
 

--- a/packages/requirements/bin/cli.js
+++ b/packages/requirements/bin/cli.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Cognitive Framework
+ *
+ * MIT License
+ */
+/**
+ * cli.js - Cognitive Framework module
+ * Auto generated documentation block.
+ *
+ * @example
+ * // require or import
+ * const mod = require('./cli.js');
+ */
+// Added in v1.0
+
+// 🚀 Quick Start
+// 🔍 Internal Design
+// 🧪 Tests
+// ⚙️ Config
+// 💡 Helpers or utilities
+'use strict';
+
+const fs = require('fs/promises');
+const { processAndTest } = require('..');
+
+async function runCLI(args = process.argv.slice(2)) {
+  const reqFile = args[0];
+  const projectPath = args[1] || process.cwd();
+  if (!reqFile) {
+    console.error('Usage: cogreq <requirement-file> [project]');
+    process.exit(1);
+  }
+  const input = await fs.readFile(reqFile, 'utf8');
+  const result = await processAndTest(input, projectPath);
+  return result;
+}
+
+if (require.main === module) {
+  runCLI().then(r => {
+    console.log(JSON.stringify(r, null, 2));
+  }).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { runCLI };
+

--- a/packages/requirements/index.js
+++ b/packages/requirements/index.js
@@ -228,6 +228,27 @@ class RequirementsFramework {
   }
 }
 
+let runCLI;
+try {
+  ({ runCLI } = require('@cognitive/ai-test-framework'));
+} catch {
+  ({ runCLI } = require('../ai-test-framework'));
+}
+
+/**
+ * Process a requirement and run the AI test framework.
+ * @param {object|string} input Requirement object or markdown text
+ * @param {string} [projectPath=process.cwd()] Project directory for tests
+ * @param {object} [options] Framework options
+ * @returns {Promise<object>} Result with requirement and test output
+ */
+async function processAndTest(input, projectPath = process.cwd(), options = {}) {
+  const rf = new RequirementsFramework(options);
+  const requirement = await rf.process(input);
+  const testResult = await runCLI([projectPath]);
+  return { requirement, testResult };
+}
+
 /**
  * exported exported API
  * @example
@@ -235,5 +256,6 @@ class RequirementsFramework {
  */
 // Added in v1.0
 module.exports = {
-  RequirementsFramework
+  RequirementsFramework,
+  processAndTest
 };

--- a/packages/requirements/package.json
+++ b/packages/requirements/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "A robust framework for defining, parsing, and managing software requirements in a way that's readable and actionable for both humans and AI",
   "main": "index.js",
+  "bin": {
+    "cogreq": "bin/cli.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "echo \"Building requirements\""


### PR DESCRIPTION
## Summary
- add `processAndTest` API in `@cognitive/requirements`
- expose new `cogreq` CLI for running requirements through Dual Mode and AI Test Framework
- document usage of the helper and CLI
- test integration of `processAndTest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a88de7d248330a98134b7cc3fbce6